### PR TITLE
Add support for redirector and web proxy

### DIFF
--- a/BootstrapScriptWithToken/bootstrap.py
+++ b/BootstrapScriptWithToken/bootstrap.py
@@ -16,7 +16,9 @@ import urlparse
 ############## USER INPUT #############
 cvAddr = ""
 enrollmentToken = ""
-
+# Add proxy url if device is behind proxy server
+# else leave it as an empty string
+cvproxy = ""
 
 ############## CONSTANTS ##############
 SECURE_HTTPS_PORT = "443"
@@ -25,6 +27,7 @@ INGEST_PORT = "9910"
 INGEST_TOKEN = "token"
 TOKEN_FILE_PATH = "/tmp/token.tok"
 BOOT_SCRIPT_PATH = "/tmp/bootstrap-script"
+REDIRECTOR_PATH = "api/v3/services/arista.redirector.v1.AssignmentService/GetOne"
 
 
 ########### HELPER FUNCTIONS ##########
@@ -49,10 +52,13 @@ class BootstrapManager( object ):
    def __init__( self ):
       super( BootstrapManager, self ).__init__()
 
+   def getBootstrapURL( self, url ):
+      pass
+
 ##################################################################################
 # step 1: get client certificate using the enrollment token
 ##################################################################################
-   def getClientCerficates( self ):
+   def getClientCertificates( self ):
       with open( TOKEN_FILE_PATH, "w" ) as f:
          f.write( enrollmentToken )
 
@@ -60,6 +66,8 @@ class BootstrapManager( object ):
       cmd += " -cvauth " + self.tokenType + "," + TOKEN_FILE_PATH
       cmd += " -cvaddr " + self.enrollAddr
       cmd += " -enrollonly"
+      cmd += " -cvproxy=" + cvproxy
+
 
       try:
          subprocess.check_output( cmd, shell=True, stderr=subprocess.STDOUT )
@@ -71,7 +79,6 @@ class BootstrapManager( object ):
 ##################################################################################
 # Step 2: get the path of stored client certificate
 ##################################################################################
-
    def getCertificatePaths( self ):
       cmd = "/usr/bin/TerminAttr"
       cmd += " -cvaddr " + self.enrollAddr
@@ -95,6 +102,21 @@ class BootstrapManager( object ):
 ##################################################################################
 # step 3 get bootstrap script using the certificates
 ##################################################################################
+   def checkWithRedirector( self, serialNum ):
+      if not self.redirectorURL:
+         return
+
+      try:
+         payload = '{"key": {"system_id": "%s"}}' % serialNum
+         response = requests.post( self.redirectorURL.geturl(), data=payload,
+               cert=( self.certificate, self.key ) )
+         response.raise_for_status()
+         clusters = response.json()[ 0 ][ "value" ][ "clusters" ][ "values" ]
+         assignment = clusters [ 0 ][ "hosts" ][ "values" ][ 0 ]
+         self.bootstrapURL = self.getBootstrapURL( assignment )
+      except Exception as e:
+         print( "error talking to redirector: %s" % e )
+         print( "no assignment found from redirector" )
 
    def getBootstrapScript( self ):
       # setting Sysdb access variables
@@ -105,7 +127,6 @@ class BootstrapManager( object ):
       cellID = str( Cell.cellId() )
       mibStatus = pathHelper.getEntity( "hardware/entmib" )
       tpmStatus = pathHelper.getEntity( "cell/" + cellID + "/hardware/tpm/status" )
-      tpmConfig = pathHelper.getEntity( "cell/" + cellID + "/hardware/tpm/config" )
 
       # setting header information
       headers = {}
@@ -116,15 +137,19 @@ class BootstrapManager( object ):
 
       headers[ 'X-Arista-TpmApi' ] = tpmStatus.tpmVersion
       headers[ 'X-Arista-TpmFwVersion' ] = tpmStatus.firmwareVersion
-      headers[ 'X-Arista-SecureZtp' ] = str( tpmConfig.antiCounterfeitingSupported )
+      headers[ 'X-Arista-SecureZtp' ] = str( tpmStatus.boardValidated )
 
       headers[ 'X-Arista-SoftwareVersion' ] = getValueFromFile(
             "/etc/swi-version", "SWI_VERSION" )
       headers[ 'X-Arista-Architecture' ] = getValueFromFile( "/etc/arch", "" )
 
+      # get the URL to the right cluster
+      self.checkWithRedirector( mibStatus.root.serialNum )
+
       # making the request and writing to file
-      response = requests.get( self.bootScriptAddr, headers=headers,
-        cert=( self.certificate, self.key ) )
+      proxies = { "https" : cvproxy }
+      response = requests.get( self.bootstrapURL.geturl(), headers=headers,
+            cert=( self.certificate, self.key ), proxies=proxies )
       response.raise_for_status()
       with open( BOOT_SCRIPT_PATH, "w" ) as f:
          f.write( response.text )
@@ -134,15 +159,17 @@ class BootstrapManager( object ):
    # execute the obtained bootstrap file
    def executeBootstrap( self ):
       cmd = "python " + BOOT_SCRIPT_PATH
+      os.environ['CVPROXY'] = cvproxy
       try:
-         subprocess.check_output( cmd, shell=True, stderr=subprocess.STDOUT )
+         subprocess.check_output( cmd, shell=True, stderr=subprocess.STDOUT,
+                                  env=os.environ )
       except subprocess.CalledProcessError as e:
          print( e.output )
          raise e
       print( "step 3.2 done, executing the fetched bootstrap script" )
 
    def run( self ):
-      self.getClientCerficates()
+      self.getClientCertificates()
       self.getCertificatePaths()
       self.getBootstrapScript()
       self.executeBootstrap()
@@ -152,35 +179,41 @@ class CloudBootstrapManager( BootstrapManager ):
    def __init__( self ):
       super( CloudBootstrapManager, self ).__init__()
 
-      cvAddrURL = urlparse.urlparse( cvAddr )
-      if cvAddrURL.netloc == "":
-         cvAddrURL = cvAddrURL._replace( path="", netloc=cvAddrURL.path )
-      if cvAddrURL.path == "":
-         cvAddrURL = cvAddrURL._replace( path="/ztp/bootstrap" )
-      if cvAddrURL.scheme == "":
-         cvAddrURL = cvAddrURL._replace( scheme="https" )
-
+      self.bootstrapURL = self.getBootstrapURL( cvAddr )
+      self.redirectorURL = self.bootstrapURL._replace( path=REDIRECTOR_PATH )
       self.tokenType = SECURE_TOKEN
-      self.enrollAddr = cvAddrURL.netloc + ":" + SECURE_HTTPS_PORT
+      self.enrollAddr = self.bootstrapURL.netloc + ":" + SECURE_HTTPS_PORT
       self.enrollAddr = self.enrollAddr.replace( "www", "apiserver" )
-      self.bootScriptAddr = cvAddrURL.geturl()
+
+   def getBootstrapURL( self, addr ):
+      addr = addr.replace( "apiserver", "www" )
+      addrURL = urlparse.urlparse( addr )
+      if addrURL.netloc == "":
+         addrURL = addrURL._replace( path="", netloc=addrURL.path )
+      if addrURL.path == "":
+         addrURL = addrURL._replace( path="/ztp/bootstrap" )
+      if addrURL.scheme == "":
+         addrURL = addrURL._replace( scheme="https" )
+      return addrURL
 
 
 class OnPremBootstrapManager( BootstrapManager ):
    def __init__( self ):
       super( OnPremBootstrapManager, self ).__init__()
 
-      cvAddrURL = urlparse.urlparse( cvAddr )
-      if cvAddrURL.netloc == "":
-         cvAddrURL = cvAddrURL._replace( path="", netloc=cvAddrURL.path )
-      if cvAddrURL.path == "":
-         cvAddrURL = cvAddrURL._replace( path="/ztp/bootstrap" )
-      if cvAddrURL.scheme == "":
-         cvAddrURL = cvAddrURL._replace( scheme="http" )
-
+      self.bootstrapURL = self.getBootstrapURL( cvAddr )
       self.tokenType = INGEST_TOKEN
-      self.enrollAddr = cvAddrURL.netloc + ":" + INGEST_PORT
-      self.bootScriptAddr = cvAddrURL.geturl()
+      self.enrollAddr = self.bootstrapURL.netloc + ":" + INGEST_PORT
+
+   def getBootstrapURL( self, addr ):
+      addrURL = urlparse.urlparse( addr )
+      if addrURL.netloc == "":
+         addrURL = addrURL._replace( path="", netloc=addrURL.path )
+      if addrURL.path == "":
+         addrURL = addrURL._replace( path="/ztp/bootstrap" )
+      if addrURL.scheme == "":
+         addrURL = addrURL._replace( scheme="http" )
+      return addrURL
 
 
 if __name__ == "__main__":

--- a/BootstrapScriptWithToken/bootstrap.py
+++ b/BootstrapScriptWithToken/bootstrap.py
@@ -202,6 +202,7 @@ class OnPremBootstrapManager( BootstrapManager ):
       super( OnPremBootstrapManager, self ).__init__()
 
       self.bootstrapURL = self.getBootstrapURL( cvAddr )
+      self.redirectorURL = None
       self.tokenType = INGEST_TOKEN
       self.enrollAddr = self.bootstrapURL.netloc + ":" + INGEST_PORT
 

--- a/BootstrapScriptWithToken/bootstrap.py
+++ b/BootstrapScriptWithToken/bootstrap.py
@@ -13,6 +13,9 @@ import urlparse
 
 
 ##############  USER INPUT  ##############
+# Note: If you are saving the file on windows, please make sure to use linux (LF) as newline.
+# By default, windows uses (CR LF), you need to convert the newline char to linux (LF).
+
 # address for CVaaS, usually just "www.arista.io"
 cvAddr = ""
 
@@ -24,6 +27,7 @@ cvproxy = ""
 
 # eosUrl is an optional parameter, which needs to be added only if the EOS version
 # is <4.24, in which case, SysDbHelperUtils is not present on the device.
+# This needs to be a http URL pointing to a SWI image on the local network.
 eosUrl = ""
 
 

--- a/BootstrapScriptWithToken/bootstrap.py
+++ b/BootstrapScriptWithToken/bootstrap.py
@@ -38,6 +38,8 @@ REDIRECTOR_PATH = "api/v3/services/arista.redirector.v1.AssignmentService/GetOne
 
 
 ##############  HELPER FUNCTIONS  ##############
+proxies = { "https" : cvproxy, "http" : cvproxy }
+
 # Given a filepath and a key, getValueFromFile searches for key=VALUE in it
 # and returns the found value without any whitespaces. In case no key specified,
 # gives the first string in the first line of the file.
@@ -159,7 +161,7 @@ class BootstrapManager( object ):
       try:
          payload = '{"key": {"system_id": "%s"}}' % serialNum
          response = requests.post( self.redirectorURL.geturl(), data=payload,
-               cert=( self.certificate, self.key ) )
+               cert=( self.certificate, self.key ), proxies=proxies )
          response.raise_for_status()
          clusters = response.json()[ 0 ][ "value" ][ "clusters" ][ "values" ]
          assignment = clusters [ 0 ][ "hosts" ][ "values" ][ 0 ]
@@ -197,7 +199,6 @@ class BootstrapManager( object ):
       self.checkWithRedirector( mibStatus.root.serialNum )
 
       # making the request and writing to file
-      proxies = { "https" : cvproxy }
       response = requests.get( self.bootstrapURL.geturl(), headers=headers,
             cert=( self.certificate, self.key ), proxies=proxies )
       response.raise_for_status()


### PR DESCRIPTION
Now, the custom bootstrap script talks to redirector to figure out what cluster the tenant is hosted on. It uses one of the received URLs to further talk to CVaaS.

This change also adds support for running the script (and hence, ZTP) in an environment where internet (i.e. CVaaS here) can only be accessed using a non-transparent web proxy.

We have also added support for customers to do device upgrades if they want. This also improves and fixes a number of bugs in the code.