### PR TITLE
Handle TPM status path not present for VM duts

### DIFF
--- a/BootstrapScriptWithToken/bootstrap.py
+++ b/BootstrapScriptWithToken/bootstrap.py
@@ -345,7 +345,6 @@ class BootstrapManager( object ):
       # sysdb paths accessed
       cellID = str( Cell.cellId() )
       mibStatus = pathHelper.getEntity( "hardware/entmib" )
-      tpmStatus = pathHelper.getEntity( "cell/" + cellID + "/hardware/tpm/status" )
 
       # setting header information
       headers = {}
@@ -354,9 +353,13 @@ class BootstrapManager( object ):
       headers[ 'X-Arista-HardwareVersion' ] = mibStatus.root.hardwareRev
       headers[ 'X-Arista-Serial' ] = mibStatus.root.serialNum
 
-      headers[ 'X-Arista-TpmApi' ] = tpmStatus.tpmVersion
-      headers[ 'X-Arista-TpmFwVersion' ] = tpmStatus.firmwareVersion
-      headers[ 'X-Arista-SecureZtp' ] = str( tpmStatus.boardValidated )
+      try:
+         tpmStatus = pathHelper.getEntity( "cell/" + cellID + "/hardware/tpm/status" )
+         headers[ 'X-Arista-TpmApi' ] = tpmStatus.tpmVersion
+         headers[ 'X-Arista-TpmFwVersion' ] = tpmStatus.firmwareVersion
+         headers[ 'X-Arista-SecureZtp' ] = str( tpmStatus.boardValidated )
+      except Exception as e:
+         log("Exception while getting device tpmStatus: %s" % e)
 
       headers[ 'X-Arista-SoftwareVersion' ] = getValueFromFile(
             "/etc/swi-version", "SWI_VERSION" )

--- a/BootstrapScriptWithToken/bootstrap_template.j2
+++ b/BootstrapScriptWithToken/bootstrap_template.j2
@@ -345,7 +345,6 @@ class BootstrapManager( object ):
       # sysdb paths accessed
       cellID = str( Cell.cellId() )
       mibStatus = pathHelper.getEntity( "hardware/entmib" )
-      tpmStatus = pathHelper.getEntity( "cell/" + cellID + "/hardware/tpm/status" )
 
       # setting header information
       headers = {}
@@ -354,9 +353,13 @@ class BootstrapManager( object ):
       headers[ 'X-Arista-HardwareVersion' ] = mibStatus.root.hardwareRev
       headers[ 'X-Arista-Serial' ] = mibStatus.root.serialNum
 
-      headers[ 'X-Arista-TpmApi' ] = tpmStatus.tpmVersion
-      headers[ 'X-Arista-TpmFwVersion' ] = tpmStatus.firmwareVersion
-      headers[ 'X-Arista-SecureZtp' ] = str( tpmStatus.boardValidated )
+      try:
+         tpmStatus = pathHelper.getEntity( "cell/" + cellID + "/hardware/tpm/status" )
+         headers[ 'X-Arista-TpmApi' ] = tpmStatus.tpmVersion
+         headers[ 'X-Arista-TpmFwVersion' ] = tpmStatus.firmwareVersion
+         headers[ 'X-Arista-SecureZtp' ] = str( tpmStatus.boardValidated )
+      except Exception as e:
+         log("Exception while getting device tpmStatus: %s" % e)
 
       headers[ 'X-Arista-SoftwareVersion' ] = getValueFromFile(
             "/etc/swi-version", "SWI_VERSION" )


### PR DESCRIPTION
We are uncertain when this path exists and when not for the VM duts and we have seen failures for the same. So better, to catch the possible exceptions.