### PR TITLE
Raise exception in checkWithRedirector when error occurs.

### DIFF
--- a/BootstrapScriptWithToken/bootstrap.py
+++ b/BootstrapScriptWithToken/bootstrap.py
@@ -19,7 +19,17 @@ import time
 # Note: If you are saving the file on windows, please make sure to use linux (LF) as newline.
 # By default, windows uses (CR LF), you need to convert the newline char to linux (LF).
 
-# address for CVaaS, usually just "www.arista.io"
+# Addresses for CVaaS
+# Note: The correct regional URL where the CVaaS tenant is deployed must be used for EOS versions
+# older than 4.30. The following are the cluster URLs used in production:
+# United States 1a: "www.arista.io"
+# United States 1b: "www.cv-prod-us-central1-b.arista.io"
+# United States 1c: "www.cv-prod-us-central1-c.arista.io"
+# Canada: "www.cv-prod-na-northeast1-b.arista.io"
+# Europe West 2: "www.cv-prod-euwest-2.arista.io"
+# Japan: "www.cv-prod-apnortheast-1.arista.io"
+# Australia: "www.cv-prod-ausoutheast-1.arista.io"
+# United Kingdon: "www.cv-prod-uk-1.arista.io"
 cvAddr = ""
 
 # enrollment token to be copied from CVaaS Device Registration page

--- a/BootstrapScriptWithToken/bootstrap.py
+++ b/BootstrapScriptWithToken/bootstrap.py
@@ -20,8 +20,9 @@ import time
 # By default, windows uses (CR LF), you need to convert the newline char to linux (LF).
 
 # Addresses for CVaaS
-# Note: The correct regional URL where the CVaaS tenant is deployed must be used for EOS versions
-# older than 4.30. The following are the cluster URLs used in production:
+# Note: If the EOS version is newer than 4.30, the URL "www.arista.io" can be used. Otherwise if
+# the EOS version is older than 4.30, the correct regional URL where the CVaaS tenant is deployed
+# must be used. The following are the cluster URLs used in production:
 # United States 1a: "www.arista.io"
 # United States 1b: "www.cv-prod-us-central1-b.arista.io"
 # United States 1c: "www.cv-prod-us-central1-c.arista.io"
@@ -346,6 +347,7 @@ class BootstrapManager( object ):
          self.bootstrapURL = self.getBootstrapURL( assignment )
       except Exception as e:
          log("No assignment found. Error talking to redirector - %s" % e )
+         raise e
 
    def getBootstrapScript( self ):
       # setting Sysdb access variables

--- a/BootstrapScriptWithToken/bootstrap_template.j2
+++ b/BootstrapScriptWithToken/bootstrap_template.j2
@@ -19,7 +19,17 @@ import time
 # Note: If you are saving the file on windows, please make sure to use linux (LF) as newline.
 # By default, windows uses (CR LF), you need to convert the newline char to linux (LF).
 
-# address for CVaaS, usually just "www.arista.io"
+# Addresses for CVaaS
+# Note: The correct regional URL where the CVaaS tenant is deployed must be used for EOS versions
+# older than 4.30. The following are the cluster URLs used in production:
+# United States 1a: "www.arista.io"
+# United States 1b: "www.cv-prod-us-central1-b.arista.io"
+# United States 1c: "www.cv-prod-us-central1-c.arista.io"
+# Canada: "www.cv-prod-na-northeast1-b.arista.io"
+# Europe West 2: "www.cv-prod-euwest-2.arista.io"
+# Japan: "www.cv-prod-apnortheast-1.arista.io"
+# Australia: "www.cv-prod-ausoutheast-1.arista.io"
+# United Kingdon: "www.cv-prod-uk-1.arista.io"
 cvAddr = {{ cvAddr }}
 
 # enrollment token to be copied from CVaaS Device Registration page

--- a/BootstrapScriptWithToken/bootstrap_template.j2
+++ b/BootstrapScriptWithToken/bootstrap_template.j2
@@ -20,8 +20,9 @@ import time
 # By default, windows uses (CR LF), you need to convert the newline char to linux (LF).
 
 # Addresses for CVaaS
-# Note: The correct regional URL where the CVaaS tenant is deployed must be used for EOS versions
-# older than 4.30. The following are the cluster URLs used in production:
+# Note: If the EOS version is newer than 4.30, the URL "www.arista.io" can be used. Otherwise if
+# the EOS version is older than 4.30, the correct regional URL where the CVaaS tenant is deployed
+# must be used. The following are the cluster URLs used in production:
 # United States 1a: "www.arista.io"
 # United States 1b: "www.cv-prod-us-central1-b.arista.io"
 # United States 1c: "www.cv-prod-us-central1-c.arista.io"
@@ -346,6 +347,7 @@ class BootstrapManager( object ):
          self.bootstrapURL = self.getBootstrapURL( assignment )
       except Exception as e:
          log("No assignment found. Error talking to redirector - %s" % e )
+         raise e
 
    def getBootstrapScript( self ):
       # setting Sysdb access variables

--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ Bootstrap script with a token provides an alternative way of ZTP enrolling an Ar
 
 - Boot up the EOS device into ZTP mode. It should download the script and enroll with the desired CVaaS cluster against the correct tenant.
 
+> Please note that the correct regional URL where the CVaaS tenant is deployed must be used for EOS versions older than 4.30. The following are the
+cluster URLs used in production:
+
+| Region | URL |
+|--------|-----|
+| United States 1a | `www.arista.io` |
+| United States 1b | `www.cv-prod-us-central1-b.arista.io`|
+| United States 1c | `www.cv-prod-us-central1-c.arista.io`|
+| Canada | `www.cv-prod-na-northeast1-b.arista.io` |
+| Europe West 2| `www.cv-prod-euwest-2.arista.io` |
+| Japan| `www.cv-prod-apnortheast-1.arista.io` |
+| Australia | `www.cv-prod-ausoutheast-1.arista.io` |
+| United Kingdon | `www.cv-prod-uk-1.arista.io` |
+
+!!! Warning
+
+    URLs without `www` are not supported.
+
 ## Troubleshooting tips
 
 ### ZTP-4-EXEC_SCRIPT_SIGNALED: Config script exited with an uncaught signal. Signal code: 1


### PR DESCRIPTION
Previously checkWithRedirector would catch an error but would never reraise or do anything with it, so getBootstrapScript continues as if no error has been raised. Fixed it so checkWithRedirector raises the error.

This pull request also pulls in some commits already in the main branch that are missing from the dev branch.